### PR TITLE
Add workdir for diagrams to Dockerfile

### DIFF
--- a/diagrams/Dockerfile
+++ b/diagrams/Dockerfile
@@ -1,3 +1,5 @@
 FROM node:14
 
 RUN apt-get update && apt-get install -y libnss3 libatk-bridge2.0 libx11-xcb1 libdrm2 libxkbcommon0 libgtk-3-0 libasound2
+
+WORKDIR /app

--- a/diagrams/README.md
+++ b/diagrams/README.md
@@ -10,8 +10,8 @@ Build the container and install the necessary tools:
 
 Generate a SVG representation of the mermaid diagram with:
 
-`docker run -it --rm -v "$PWD:/app" -w /app  diagrams node_modules/.bin/mmdc -i main.mmd -o output.svg`
+`docker run -it --rm -v "$PWD:/app" diagrams node_modules/.bin/mmdc -i main.mmd -o output.svg`
 
 If you get a Chrome error `Running as root without --no-sandbox is not supported` you might need to use the `--no-sandbox` option of the Puppeteer.
 
-`docker run -it --rm -v "$PWD:/app" -w /app  diagrams node_modules/.bin/mmdc -p puppeteer-config.json -i main.mmd -o output.svg`
+`docker run -it --rm -v "$PWD:/app" diagrams node_modules/.bin/mmdc -p puppeteer-config.json -i main.mmd -o output.svg`


### PR DESCRIPTION
I looked at (and copied) these files for use making some other diagrams.
I saw this as one small improvement to make the README slightly easier to follow (purley as it will have less words)