### PR TITLE
ADR0011 - Wikibase bundle tarball/docker image

### DIFF
--- a/docs/adr/0011-wikibase-bundle.md
+++ b/docs/adr/0011-wikibase-bundle.md
@@ -9,18 +9,18 @@ accepted
 ## Context
 
 A key part of release pipeline is to produce a bundled wikibase docker image prepared with the extensions and components known as the "wikibase suite".
-This bundle image will consist of the build artifacts and as described in [ADR0001](0001-docker-image-repository.md) we've decided these images should be published to dockerhub.
+This bundle image will consist of the build artifacts and as described in [ADR0001](0001-docker-image-repository.md) these images should be published to dockerhub.
 
-In previous wikibase docker artifacts WMDE has offered a "base" and a "bundled" version of Wikibase, the new pipeline should still produce and publish these artifacts. The base image did only contain mediawiki and wikibase.
+In previous wikibase docker artifacts WMDE has offered a "base" and a "bundled" version of Wikibase where the base version only contain mediawiki and Wikibase. The new pipeline should still produce and publish these artifacts.
 
-As we publish our releases we also need to make a decision if we want this bundle version to be available in a tarball for the user to install manually.
+As we publish our releases we also need to make a decision if we want this bundle version to be available in a tarball for the user to install manually. In a daily today this topic was discussed and the team decided against it.
 
 ## Decision
 
-The wikibase release pipeline will not produce a bundled tarball. 
+The wikibase release pipeline will not produce a bundled tarball to be published. 
 
 ## Consequences
 
-- No bundled tarball will be produced
+- No bundled tarball will be published
 - A bundled wikibase docker image and a base image will be produced
 

--- a/docs/adr/0011-wikibase-bundle.md
+++ b/docs/adr/0011-wikibase-bundle.md
@@ -1,0 +1,26 @@
+# 11) Wikibase bundles {#adr_0011}
+
+Date: 2021-01-26
+
+## Status
+
+accepted
+
+## Context
+
+A key part of release pipeline is to produce a bundled wikibase docker image prepared with the extensions and components known as the "wikibase suite".
+This bundle image will consist of the build artifacts and as described in [ADR0001](0001-docker-image-repository.md) we've decided these images should be published to dockerhub.
+
+In previous wikibase docker artifacts WMDE has offered a "base" and a "bundled" version of Wikibase, the new pipeline should still produce and publish these artifacts. The base image did only contain mediawiki and wikibase.
+
+As we publish our releases we also need to make a decision if we want this bundle version to be available in a tarball for the user to install manually.
+
+## Decision
+
+The wikibase release pipeline will not produce a bundled tarball. 
+
+## Consequences
+
+- No bundled tarball will be produced
+- A bundled wikibase docker image and a base image will be produced
+

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -11,7 +11,13 @@ Superseding decisions should reference ADRs they're changing or overriding.
 
 Current ADRs include:
 
-* @subpage adr_0001
-* @subpage adr_0002
-* @subpage adr_0003
-* @subpage adr_0004
+* [1 - docker image repository](0001-docker-image-repository.md)
+* [2 - tarball hosting](0002-tarball-hosting.md)
+* [3 - tarball contents](0003-tarball-contents.md)
+* [4 - wdqs tarball contents](0004-wdqs-tarball-content.md)
+* [5 - release notes process](0005-release-notes-process.md)
+* [6 - pipeline runner](0006-pipline-runner.md)
+* [7 - wikibase release notes publishing](0007-wikibase-release-notes-publish.md)
+* [9 - non-WMDE release notes](0009-non-WMDE-release-notes.md)
+* [10 - queryservice tarball](0010-queryservice-tarball.md)
+* [11 - wikibase bundle](0011-wikibase-bundle.md)


### PR DESCRIPTION
- Add ADR on decision not to publish/create a wikibase bundle tarball, but create a bundle and base docker image.
- Add index