### PR TITLE
Made a point on not communicated changes in non-WMDE software less dramatic

### DIFF
--- a/docs/adr/0009-non-WMDE-release-notes.md
+++ b/docs/adr/0009-non-WMDE-release-notes.md
@@ -34,4 +34,4 @@ When adding components to the release pipeline that have curated release notes w
 
 If upstream components start providing release notes we should make changes to include them in the appropriate artifacts when possible.
 
-Other components may have significant changes that we fail to inform users of in advance.
+Other components may have significant changes that we might fail to inform users of in advance.


### PR DESCRIPTION
WMDE will not have a "release notes" document for the other party's software which does not provide such a document, but it is not impossible to imagine that we'll know there is a huge changes in, say, Quick Statements, we still might inform users about it - just in a different form than release notes document.