### PR TITLE
some fixes for building REL1_35 branch

### DIFF
--- a/build/build_mediawiki.sh
+++ b/build/build_mediawiki.sh
@@ -12,12 +12,15 @@ if [ ! -d "$MEDIAWIKI_DIR" ]; then
    git clone --branch "$MEDIAWIKI_BRANCH_NAME" "$ROOT/git_cache/core.git" "$MEDIAWIKI_DIR"
 fi
 
-# Add vector from cache
-if [ ! -d "$MEDIAWIKI_DIR/skins/Vector" ]; then
-   git clone --branch "$MEDIAWIKI_BRANCH_NAME" "$ROOT/git_cache/skins/Vector.git" "$MEDIAWIKI_DIR/skins/Vector"
+# remove any existing folders
+if [ -d "$MEDIAWIKI_DIR/skins/Vector" ]; then
+    rm -rf "$MEDIAWIKI_DIR/skins/Vector"
 fi
 
+git clone --branch "$MEDIAWIKI_BRANCH_NAME" "$ROOT/git_cache/skins/Vector.git" "$MEDIAWIKI_DIR/skins/Vector"
+
 # remove git things from release package
+rm "$MEDIAWIKI_DIR/skins/Vector".git* -rfv
 rm "$MEDIAWIKI_DIR/".git* -rfv
 
 GZIP=-9 tar -C "$TEMP_GIT_DIR" -zcf "$TARBALL_PATH" mediawiki

--- a/build/build_mediawiki.sh
+++ b/build/build_mediawiki.sh
@@ -12,11 +12,8 @@ if [ ! -d "$MEDIAWIKI_DIR" ]; then
    git clone --branch "$MEDIAWIKI_BRANCH_NAME" "$ROOT/git_cache/core.git" "$MEDIAWIKI_DIR"
 fi
 
-# remove any existing folders
-if [ -d "$MEDIAWIKI_DIR/skins/Vector" ]; then
-    rm -rf "$MEDIAWIKI_DIR/skins/Vector"
-fi
-
+# Add Vector skin
+rm -rf "$MEDIAWIKI_DIR/skins/Vector" # remove any existing folders
 git clone --branch "$MEDIAWIKI_BRANCH_NAME" "$ROOT/git_cache/skins/Vector.git" "$MEDIAWIKI_DIR/skins/Vector"
 
 # remove git things from release package

--- a/test/suite-config/fedprops/LocalSettings.php
+++ b/test/suite-config/fedprops/LocalSettings.php
@@ -8,8 +8,12 @@ $wgDebugDumpSql  = true;
 $wgShowDBErrorBacktrace = true;
 
 $wgWBRepoSettings['federatedPropertiesEnabled'] = true;
-$wgWBRepoSettings['federatedPropertiesSourceScriptUrl'] = 'https://www.wikidata.org/w/';
 
+/**
+ *  Manually setup the default federated properties entitySources
+ *  The following can be removed once we drop support for 1.35
+ */
+$wgWBRepoSettings['federatedPropertiesSourceScriptUrl'] = 'https://www.wikidata.org/w/';
 $wgWBRepoSettings['entitySources'] = [
     'local' => [
         'entityNamespaces' => [ 'item' => 120 ],

--- a/test/suite-config/fedprops/LocalSettings.php
+++ b/test/suite-config/fedprops/LocalSettings.php
@@ -8,3 +8,23 @@ $wgDebugDumpSql  = true;
 $wgShowDBErrorBacktrace = true;
 
 $wgWBRepoSettings['federatedPropertiesEnabled'] = true;
+$wgWBRepoSettings['federatedPropertiesSourceScriptUrl'] = 'https://www.wikidata.org/w/';
+
+$wgWBRepoSettings['entitySources'] = [
+    'local' => [
+        'entityNamespaces' => [ 'item' => 120 ],
+        'repoDatabase' => false,
+        'baseUri' => 'http://wikibase.svc/entity/',
+        'interwikiPrefix' => '',
+        'rdfNodeNamespacePrefix' => 'wd',
+        'rdfPredicateNamespacePrefix' => 'wdt',
+    ],
+    'fedprops' => [
+        'entityNamespaces' => [ 'property' => 122 ],
+        'repoDatabase' => false,
+        'baseUri' => 'http://www.wikidata.org/entity/',
+        'interwikiPrefix' => 'wikidata',
+        'rdfNodeNamespacePrefix' => 'fpwd',
+        'rdfPredicateNamespacePrefix' => 'fpwd',
+    ],
+];


### PR DESCRIPTION
- mw REL1_35 for some reasons contain the Vector folder so this is now
removed always and cloned.
- Fedprops auto-setup is not in REL1_35 so we can use the manual setup
to skip relying on it.